### PR TITLE
Add conditional logic to kibana's dep on hap

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -31,4 +31,6 @@ galaxy_info:
 
 dependencies:
   - pip_install
-  - haproxy_server
+  - role: haproxy_server
+    when:
+      - groups[haproxy_all] | length > 0


### PR DESCRIPTION
The haproxy role was being included no matter if haproxy was actually
deployed. This change makes it so kibana will only run the hap
dependency when there are hap hosts to interact with.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>